### PR TITLE
Add udp endpoint basics

### DIFF
--- a/src/layer/ip/endpoint.rs
+++ b/src/layer/ip/endpoint.rs
@@ -1,7 +1,7 @@
 use crate::layer::{eth, FnHandler};
 use crate::managed::Slice;
-use crate::wire::{Checksum, EthernetProtocol, Payload, PayloadMut};
-use crate::wire::{IpAddress, IpCidr, Ipv4Cidr, Ipv6Cidr, Ipv4Packet, Ipv6Packet};
+use crate::wire::{EthernetProtocol, Payload, PayloadMut};
+use crate::wire::{IpAddress, IpCidr, Ipv4Cidr, Ipv6Cidr, Ipv4Packet};
 use crate::time::Instant;
 
 use super::{Recv, Send};

--- a/src/layer/udp/endpoint.rs
+++ b/src/layer/udp/endpoint.rs
@@ -1,8 +1,13 @@
-use crate::managed::Ordered;
+use crate::layer::{ip, FnHandler};
+use crate::managed::Slice;
+use crate::wire::{IpProtocol, Payload, PayloadMut, UdpPacket};
+
+use super::{Recv, Send};
+use super::packet::{Handle, Packet, RawPacket};
 
 pub struct Endpoint<'a> {
     /// List of accepted ports for lookup.
-    ports: Ordered<'a, u16>,
+    ports: Slice<'a, u16>,
 }
 
 /// An endpoint borrowed for receiving.
@@ -15,7 +20,8 @@ pub struct Receiver<'a, 'e, H> {
 
 /// An endpoint borrowed for sending.
 pub struct Sender<'a, 'e, H> {
-    endpoint: UdpEndpoint<'a, 'e>,
+    // FIXME: I don't know, maybe we should need it for selecting a source port?
+    _endpoint: UdpEndpoint<'a, 'e>,
 
     /// The upper protocol sender.
     handler: H,
@@ -26,3 +32,98 @@ struct UdpEndpoint<'a, 'e> {
 }
 
 
+impl<'a> Endpoint<'a> {
+    pub fn new<A>(ports: A) -> Self 
+        where A: Into<Slice<'a, u16>>,
+    {
+        Endpoint {
+            ports: ports.into(),
+        }
+    }
+
+    pub fn recv<H>(&mut self, handler: H) -> Receiver<'_, 'a, H> {
+        Receiver { endpoint: self.get_mut(), handler, }
+    }
+
+    pub fn recv_with<H>(&mut self, handler: H) -> Receiver<'_, 'a, FnHandler<H>> {
+        self.recv(FnHandler(handler))
+    }
+
+    pub fn send<H>(&mut self, handler: H) -> Sender<'_, 'a, H> {
+        Sender { _endpoint: self.get_mut(), handler, }
+    }
+
+    pub fn send_with<H>(&mut self, handler: H) -> Sender<'_, 'a, FnHandler<H>> {
+        self.send(FnHandler(handler))
+    }
+
+    fn accepts(&self, port: u16) -> bool {
+        self.ports.as_slice().contains(&port)
+    }
+
+    fn get_mut(&mut self) -> UdpEndpoint<'_, 'a> {
+        UdpEndpoint {
+            inner: self,
+        }
+    }
+}
+
+impl<P, H> ip::Recv<P> for Receiver<'_, '_, H>
+where
+    P: Payload,
+    H: Recv<P>,
+{
+    fn receive(&mut self, packet: ip::Packet<P>) {
+        let capabilities = packet.handle.info().capabilities();
+        let ip::Packet { handle, packet } = packet;
+        let checksum = capabilities.udp().rx_checksum(packet.repr());
+
+        let packet = match packet.repr().protocol() {
+            IpProtocol::Udp => {
+                match UdpPacket::new_checked(packet, checksum) {
+                    Ok(packet) => packet,
+                    Err(_) => return,
+                }
+            },
+            _ => return,
+        };
+
+        if !self.endpoint.inner.accepts(packet.repr().dst_port) {
+            return
+        }
+
+        let handle = Handle::new(handle);
+        let packet = Packet::new(handle, packet);
+        self.handler.receive(packet);
+    }
+}
+
+impl<P, H> ip::Send<P> for Sender<'_, '_, H>
+where
+    P: Payload + PayloadMut,
+    H: Send<P>,
+{
+    fn send<'a>(&mut self, packet: ip::RawPacket<'a, P>) {
+        let ip::RawPacket { handle, payload } = packet;
+        let handle = Handle::new(handle);
+        let packet = RawPacket::new(handle, payload);
+
+        self.handler.send(packet)
+    }
+}
+
+impl<P: Payload, F> Recv<P> for FnHandler<F>
+    where F: FnMut(Packet<P>)
+{
+    fn receive(&mut self, frame: Packet<P>) {
+        self.0(frame)
+    }
+}
+
+impl<P: Payload, F> Send<P> for FnHandler<F>
+    where F: FnMut(RawPacket<P>)
+{
+    fn send(&mut self, frame: RawPacket<P>) {
+        self.0(frame)
+    }
+}

--- a/src/layer/udp/mod.rs
+++ b/src/layer/udp/mod.rs
@@ -5,9 +5,18 @@
 //! possible to respond dynamically at any port without settting up logic prior to a packet
 //! arriving (e.g. dynamic port knocking) but also simplifies implementation by enforcing clear cut
 //! separation of concerns.
+use crate::wire::Payload;
 
 mod endpoint;
 mod packet;
+#[cfg(test)]
+mod tests;
+
+pub use endpoint::{
+    Endpoint,
+    Receiver,
+    Sender,
+};
 
 pub use packet::{
     Handle,
@@ -15,3 +24,11 @@ pub use packet::{
     Packet,
     RawPacket,
 };
+
+pub trait Recv<P: Payload> {
+    fn receive(&mut self, frame: Packet<P>);
+}
+
+pub trait Send<P: Payload> {
+    fn send(&mut self, raw: RawPacket<P>);
+}

--- a/src/layer/udp/tests.rs
+++ b/src/layer/udp/tests.rs
@@ -1,0 +1,85 @@
+use crate::managed::Slice;
+use crate::nic::{external::External, Device};
+use crate::layer::{eth, ip, udp};
+use crate::wire::{EthernetAddress, Ipv4Address, IpCidr, Ipv4Cidr, Payload, PayloadMut};
+use crate::wire::{ethernet_frame, ipv4_packet};
+
+const MAC_ADDR_SRC: EthernetAddress = EthernetAddress([0, 1, 2, 3, 4, 5]);
+const IP_ADDR_SRC: Ipv4Address = Ipv4Address::new(127, 0, 0, 1);
+const MAC_ADDR_DST: EthernetAddress = EthernetAddress([6, 5, 4, 3, 2, 1]);
+const IP_ADDR_DST: Ipv4Address = Ipv4Address::new(127, 0, 0, 2);
+
+static PAYLOAD_BYTES: [u8; 50] =
+    [0xaa, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+     0x00, 0xff];
+
+fn simple_send<P: PayloadMut>(frame: udp::RawPacket<P>) {
+    let init = udp::Init {
+        src_mask: Ipv4Cidr::UNSPECIFIED.into(),
+        src_port: 80,
+        dst_addr: IP_ADDR_DST.into(),
+        dst_port: 80,
+        payload: PAYLOAD_BYTES.len(),
+    };
+    let mut prepared = frame.prepare(init)
+        .expect("Found no valid routes");
+    prepared
+        .packet
+        .payload_mut()
+        .copy_from_slice(&PAYLOAD_BYTES[..]);
+    prepared.send()
+        .expect("Could actuall egress packet");
+}
+
+fn simple_recv<P: Payload>(frame: udp::Packet<P>) {
+    assert_eq!(frame.packet.payload().as_slice(), &PAYLOAD_BYTES[..]);
+}
+
+#[test]
+fn simple() {
+    let mut nic = External::new_send(Slice::One(vec![0; 1024]));
+
+    let mut eth = [eth::Neighbor::default(); 1];
+    let mut eth = eth::Endpoint::new(MAC_ADDR_SRC, {
+        let mut eth_cache = eth::NeighborCache::new(&mut eth[..]);
+        eth_cache.fill(IP_ADDR_DST.into(), MAC_ADDR_DST, None).unwrap();
+        eth_cache
+    });
+
+    let mut ip = [ip::Route::unspecified(); 2];
+    let mut ip = ip::Endpoint::new(IpCidr::new(IP_ADDR_SRC.into(), 24), {
+        let ip_routes = ip::Routes::new(&mut ip[..]);
+        // No routes necessary for local link.
+        ip_routes
+    });
+
+    let mut udp = udp::Endpoint::new(80);
+
+    let sent = nic.tx(1, eth.send(ip.send(
+        udp.send_with(simple_send))));
+    assert_eq!(sent, Ok(1));
+
+    {
+        // Retarget the packet to self.
+        let buffer = nic.get_mut(0).unwrap();
+        let eth = ethernet_frame::new_unchecked_mut(buffer);
+        eth.set_dst_addr(MAC_ADDR_SRC);
+        eth.set_src_addr(MAC_ADDR_DST);
+        let ip = ipv4_packet::new_unchecked_mut(eth.payload_mut_slice());
+        ip.set_dst_addr(IP_ADDR_SRC);
+        ip.set_src_addr(IP_ADDR_DST);
+        ip.fill_checksum();
+    }
+
+    // Set the buffer to be received.
+    nic.receive_all();
+
+    let recv = nic.rx(1, eth.recv(ip.recv(
+        udp.recv_with(simple_recv))));
+   assert_eq!(recv, Ok(1)); 
+}


### PR DESCRIPTION
This is unlikely the final version. Giving the source addresses and port
explicitely for every packet seems rather inconvenient but was
inherited from the ip endpoint design. Since this requires a lookup for
every sent packet (finding one fitting source address) it is also
overhead we want to avoid. An alternative is providing the address as an
index based lookup instead or as a variant.

This design will come into question once more with TCP where connection
state needs to be present for (src, src_port, dst, dst_port) tuples.