### PR TITLE
Icmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ A significant portion of the original network code comes from `smoltcp`,
 copyright `whitequark@whitequark.org`, and reproduced and modified here under
 the terms allowed by its 0-clause BSD license. It may have changed a lot by the
 time you read this.
+
+## TODO
+
+* Ipv6
+* Icmpv6
+* Tcp

--- a/src/layer/eth/endpoint.rs
+++ b/src/layer/eth/endpoint.rs
@@ -4,7 +4,7 @@ use crate::wire::{EthernetAddress, EthernetFrame, IpAddress,  Payload, PayloadMu
 use crate::nic;
 
 use super::{Recv, Send};
-use super::packet::{self, Handle, Packet, RawPacket};
+use super::packet::{self, Handle};
 use super::neighbor::{Cache};
 
 pub struct Endpoint<'a> {
@@ -112,7 +112,7 @@ where
         }
 
         let handle = Handle::new(packet.handle, &mut self.endpoint);
-        let packet = Packet::new(handle, frame);
+        let packet = packet::In { handle, frame };
         self.handler.receive(packet)
     }
 }
@@ -123,26 +123,25 @@ where
     P: Payload + PayloadMut,
     T: Send<P>,
 {
-    fn send(&mut self, packet: nic::Packet<H, P>) {
-        let handle = Handle::new(packet.handle, &mut self.endpoint);
-        let packet = RawPacket::new(handle, packet.payload);
-
+    fn send(&mut self, nic::Packet { handle, payload }: nic::Packet<H, P>) {
+        let handle = Handle::new(handle, &mut self.endpoint);
+        let packet = packet::Raw { handle, payload };
         self.handler.send(packet)
     }
 }
 
 impl<P: Payload, F> Recv<P> for FnHandler<F>
-    where F: FnMut(Packet<P>)
+    where F: FnMut(packet::In<P>)
 {
-    fn receive(&mut self, frame: Packet<P>) {
+    fn receive(&mut self, frame: packet::In<P>) {
         self.0(frame)
     }
 }
 
 impl<P: Payload, F> Send<P> for FnHandler<F>
-    where F: FnMut(RawPacket<P>)
+    where F: FnMut(packet::Raw<P>)
 {
-    fn send(&mut self, frame: RawPacket<P>) {
+    fn send(&mut self, frame: packet::Raw<P>) {
         self.0(frame)
     }
 }
@@ -166,7 +165,7 @@ mod tests {
          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
          0x00, 0xff];
 
-    fn simple_send<P: Payload + PayloadMut>(mut frame: RawPacket<P>) {
+    fn simple_send<P: Payload + PayloadMut>(mut frame: packet::Raw<P>) {
         let src_addr = frame.src_addr();
         let init = Init {
             src_addr,
@@ -177,7 +176,6 @@ mod tests {
         let mut prepared = frame.prepare(init)
             .expect("Preparing frame mustn't fail in controlled environment");
         prepared
-            .frame()
             .payload_mut_slice()
             .copy_from_slice(&PAYLOAD_BYTES[..]);
         prepared
@@ -185,7 +183,7 @@ mod tests {
             .expect("Sending is possible");
     }
 
-    fn simple_recv<P: Payload>(mut frame: Packet<P>) {
+    fn simple_recv<P: Payload>(mut frame: packet::In<P>) {
         assert_eq!(frame.frame().payload().as_slice(), &PAYLOAD_BYTES[..]);
     }
 

--- a/src/layer/eth/endpoint.rs
+++ b/src/layer/eth/endpoint.rs
@@ -166,7 +166,7 @@ mod tests {
          0x00, 0xff];
 
     fn simple_send<P: Payload + PayloadMut>(mut frame: packet::Raw<P>) {
-        let src_addr = frame.src_addr();
+        let src_addr = frame.handle.src_addr();
         let init = Init {
             src_addr,
             dst_addr: MAC_ADDR_1,

--- a/src/layer/eth/mod.rs
+++ b/src/layer/eth/mod.rs
@@ -22,12 +22,13 @@ pub use neighbor::{
 pub use packet::{
     Handle,
     Init,
-    Packet,
-    RawPacket,
+    In as InPacket,
+    Out as OutPacket,
+    Raw as RawPacket,
 };
 
 pub trait Recv<P: Payload> {
-    fn receive(&mut self, frame: Packet<P>);
+    fn receive(&mut self, frame: InPacket<P>);
 }
 
 pub trait Send<P: Payload> {
@@ -37,7 +38,7 @@ pub trait Send<P: Payload> {
 /// Available only on `std` because it prints to standard out.
 #[cfg(feature = "std")]
 impl<P: Payload> Recv<P> for Formatter<ethernet_frame> {
-    fn receive(&mut self, frame: Packet<P>) {
+    fn receive(&mut self, frame: InPacket<P>) {
         let printer = PrettyPrinter::<ethernet_frame>::print(&frame.frame);
         eprintln!("{}", printer);
     }

--- a/src/layer/eth/packet.rs
+++ b/src/layer/eth/packet.rs
@@ -16,6 +16,7 @@ pub struct In<'a, P: Payload> {
 ///
 /// While the layers below have been initialized, the payload of the packet has not. Fill it by
 /// grabbing the mutable slice for example.
+#[must_use = "You need to call `send` explicitely on an OutPacket, otherwise no packet is sent."]
 pub struct Out<'a, P: Payload> {
     handle: Handle<'a>,
     frame: EthernetFrame<&'a mut P>,

--- a/src/layer/eth/packet.rs
+++ b/src/layer/eth/packet.rs
@@ -117,25 +117,25 @@ impl<'a, P: PayloadMut> In<'a, P> {
             ethertype: init.ethertype,
         };
         let raw_repr = frame.repr();
-        let raw_packet = frame.into_inner();
+        let raw_buffer = frame.into_inner();
 
-        let raw_len = raw_packet.payload().len();
-        let raw_payload = raw_repr.header_len() - raw_len;
+        let raw_len = raw_buffer.payload().len();
+        let raw_payload = raw_len - raw_repr.header_len();
 
         // The payload is the common tail.
         let payload = init.payload.min(raw_payload);
         let old_payload = raw_len - payload..raw_len;
         let new_payload = new_len - payload..new_len;
 
-        raw_packet.reframe_payload(ReframePayload {
+        raw_buffer.reframe_payload(ReframePayload {
             length: new_len,
             old_payload,
             new_payload,
         })?;
 
         // Now emit the header again:
-        new_repr.emit(ethernet_frame::new_unchecked_mut(raw_packet.payload_mut()));
-        let frame = EthernetFrame::new_unchecked(raw_packet, new_repr);
+        new_repr.emit(ethernet_frame::new_unchecked_mut(raw_buffer.payload_mut()));
+        let frame = EthernetFrame::new_unchecked(raw_buffer, new_repr);
 
         Ok(Out {
             handle,

--- a/src/layer/eth/packet.rs
+++ b/src/layer/eth/packet.rs
@@ -71,6 +71,10 @@ impl<'a> Handle<'a> {
         self.nic_handle.info()
     }
 
+    pub fn src_addr(&mut self) -> EthernetAddress {
+        self.endpoint.src_addr()
+    }
+
     /// Try to initialize the destination from an upper layer protocol address.
     ///
     /// Failure to satisfy the request is clearly signalled. Use the result to initialize the
@@ -181,10 +185,6 @@ impl<'a, P: Payload + PayloadMut> Raw<'a, P> {
         payload: &'a mut P) -> Self
     {
         Raw { handle, payload, }
-    }
-
-    pub fn src_addr(&mut self) -> EthernetAddress {
-        self.handle.endpoint.src_addr()
     }
 
     pub fn prepare(self, init: Init) -> Result<Out<'a, P>> {

--- a/src/layer/icmp/endpoint.rs
+++ b/src/layer/icmp/endpoint.rs
@@ -1,0 +1,159 @@
+use crate::layer::{ip, FnHandler};
+use crate::wire::{Error, Icmpv4Repr, Icmpv4Packet, IpProtocol, PayloadMut};
+
+use super::packet::{Handle, Packet, RawPacket};
+use super::{Recv, Send};
+
+/// The default handler type when none has been configured.
+///
+/// No instance can be created and should never be. This type provides an implementation of an
+/// upper layer receiver but its methods can never be invoked since they can no have a receiver.
+/// This has no representation but that is an implementation details that is not otherwise exposed.
+pub struct NoHandler { _private: Empty, }
+
+/// An empty enum to prove that there is no instance of `NoHandler`.
+enum Empty { }
+
+/// An icmp traffic handler.
+///
+/// [WIP]: No idea what state is necessary for an icmp endpoint? Answering pings at least doesn't
+/// take any. Suppose there could be some config involved in router solicitation, timestamps, icmp
+/// extended echo authorization, ...
+#[derive(Default)]
+pub struct Endpoint {
+    /// Drops echo requests if enabled.
+    ///
+    /// This is off by default, as required in RFC1812, but can be enabled to avoid answering echo
+    /// requests on some node. Might be done for some routers.
+    deny_echo: bool,
+
+    /// Determine if all echos are forwarded to the upper handler.
+    ///
+    /// If enabled but no handler is configured then these requests are simply dropped.
+    manual_echo: bool,
+}
+
+/// An endpoint borrowed for receiving.
+///
+/// Dispatching to higher protocols is configured here, and not in the endpoint state.
+pub struct Receiver<'a, H=NoHandler> {
+    endpoint: EndpointRef<'a>,
+
+    /// The receiver for any unhandled messages.
+    handler: Option<H>,
+}
+
+/// An icmp endpoint for sending.
+pub struct Sender<'a, H> {
+    endpoint: EndpointRef<'a>,
+
+    /// The upper protocol sender.
+    handler: H,
+}
+
+struct EndpointRef<'a> {
+    inner: &'a Endpoint,
+}
+
+enum HandlingKind<'a, P: PayloadMut> {
+    /// The upper layer handler should not need to see this packet.
+    Internal,
+
+    /// Give the packet to upper layer handler if that exists.
+    ToUpperLayer(Packet<'a, P>),
+}
+
+impl Endpoint {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A receiver that only answers pings.
+    pub fn answer(&mut self) -> Receiver {
+        Receiver { endpoint: self.get_mut(), handler: None, }
+    }
+
+    pub fn recv<H>(&mut self, handler: H) -> Receiver<H> {
+        Receiver { endpoint: self.get_mut(), handler: Some(handler), }
+    }
+
+    pub fn recv_with<H>(&mut self, handler: H) -> Receiver<FnHandler<H>> {
+        self.recv(FnHandler(handler))
+    }
+
+    pub fn send<H>(&mut self, handler: H) -> Sender<H> {
+        Sender { endpoint: self.get_mut(), handler, }
+    }
+
+    pub fn send_with<H>(&mut self, handler: H) -> Sender<FnHandler<H>> {
+        self.send(FnHandler(handler))
+    }
+
+    /// Get this by mutable reference for a receiver or sender.
+    // Mutable technically unused but not sure right now.
+    fn get_mut(&mut self) -> EndpointRef {
+        EndpointRef { inner: self }
+    }
+}
+
+impl EndpointRef<'_> {
+    /// Try to answer or otherwise handle the packet without propagating it upwards.
+    fn handle_internally<'a, P: PayloadMut>(&mut self, packet: Packet<'a, P>)
+        -> HandlingKind<'a, P>
+    {
+        match packet.packet.repr() {
+            Icmpv4Repr::EchoRequest { .. } if self.inner.manual_echo => {
+                HandlingKind::ToUpperLayer(packet)
+            },
+            Icmpv4Repr::EchoRequest { ident, seq_no, payload } => {
+                if self.inner.deny_echo {
+                    return HandlingKind::Internal
+                }
+
+                unimplemented!("construct and return the echo response");
+                HandlingKind::Internal
+            },
+            _ => HandlingKind::ToUpperLayer(packet),
+        }
+    }
+}
+
+impl<P, H> ip::Recv<P> for Receiver<'_, H>
+where
+    P: PayloadMut,
+    H: Recv<P>,
+{
+    fn receive(&mut self, packet: ip::Packet<P>) {
+        let ip::Packet { handle, packet } = packet;
+        let capabilities = handle.info().capabilities();
+
+        let icmp = match packet {
+            ip::IpPacket::V4(packet) => {
+                if packet.repr().protocol != IpProtocol::Icmp {
+                    return;
+                }
+
+                match Icmpv4Packet::new_checked(packet, capabilities.icmpv4().rx_checksum()) {
+                    Ok(packet) => packet,
+                    Err(Error::Unsupported) => unimplemented!("Forward to upper layer"),
+                    Err(_) => return,
+                }
+            },
+            // Handle icmpv6
+            _ => return,
+        };
+
+        let handle = Handle::new(handle);
+        let packet = Packet::new(handle, icmp);
+
+        let how_to_handle = self.endpoint.handle_internally(packet);
+
+        match (how_to_handle, self.handler.as_mut()) {
+            (HandlingKind::Internal, _) => (),
+            (HandlingKind::ToUpperLayer(packet), Some(handler)) => {
+                handler.receive(packet)
+            },
+            _ => (),
+        }
+    }
+}

--- a/src/layer/icmp/endpoint.rs
+++ b/src/layer/icmp/endpoint.rs
@@ -123,8 +123,7 @@ where
     P: PayloadMut,
     H: Recv<P>,
 {
-    fn receive(&mut self, packet: ip::Packet<P>) {
-        let ip::Packet { handle, packet } = packet;
+    fn receive(&mut self, ip::InPacket { handle, packet }: ip::InPacket<P>) {
         let capabilities = handle.info().capabilities();
 
         let icmp = match packet {

--- a/src/layer/icmp/endpoint.rs
+++ b/src/layer/icmp/endpoint.rs
@@ -110,7 +110,9 @@ impl EndpointRef<'_> {
                     return Ok(HandlingKind::Internal)
                 }
 
-                packet.answer()?;
+                packet
+                    .answer()?
+                    .send()?;
 
                 Ok(HandlingKind::Internal)
             },

--- a/src/layer/icmp/mod.rs
+++ b/src/layer/icmp/mod.rs
@@ -42,12 +42,13 @@ pub use endpoint::{
 pub use packet::{
     Handle,
     Init,
-    Packet,
-    RawPacket,
+    In as InPacket,
+    Out as OutPacket,
+    Raw as RawPacket,
 };
 
 pub trait Recv<P: Payload> {
-    fn receive(&mut self, frame: Packet<P>);
+    fn receive(&mut self, frame: InPacket<P>);
 }
 
 pub trait Send<P: Payload> {

--- a/src/layer/icmp/mod.rs
+++ b/src/layer/icmp/mod.rs
@@ -1,5 +1,7 @@
 //! Receiving and sending Icmp messages.
 //!
+//! Only supports Icmpv4 for now.
+//!
 //! Tuned to automate most parts of the icmp procedures *internally*. Nevertheless it will has an
 //! optional interface to forward unhandled messages to a custom receiver. This is in accorance
 //! with RFC1812, and extends it to unhandled packets, which states:
@@ -26,5 +28,28 @@
 //!
 //! All other message types can be received in an upper layer or are simply discarded if there is
 //! no upper handler that is ready to inspect packets.
+use crate::wire::Payload;
 
+mod endpoint;
+mod packet;
 
+pub use endpoint::{
+    Endpoint,
+    Receiver,
+    Sender,
+};
+
+pub use packet::{
+    Handle,
+    Init,
+    Packet,
+    RawPacket,
+};
+
+pub trait Recv<P: Payload> {
+    fn receive(&mut self, frame: Packet<P>);
+}
+
+pub trait Send<P: Payload> {
+    fn send(&mut self, raw: RawPacket<P>);
+}

--- a/src/layer/icmp/mod.rs
+++ b/src/layer/icmp/mod.rs
@@ -32,6 +32,8 @@ use crate::wire::Payload;
 
 mod endpoint;
 mod packet;
+#[cfg(test)]
+mod tests;
 
 pub use endpoint::{
     Endpoint,

--- a/src/layer/icmp/packet.rs
+++ b/src/layer/icmp/packet.rs
@@ -1,0 +1,160 @@
+use crate::nic::Info;
+use crate::layer::{Error, Result, ip};
+use crate::wire::{Payload, PayloadMut};
+use crate::wire::{Checksum, IpAddress, IpCidr, IpProtocol};
+use crate::wire::{Icmpv4Packet, Icmpv4Repr, icmpv4_packet};
+
+pub struct Packet<'a, P: Payload> {
+    pub handle: Handle<'a>,
+    pub packet: Icmpv4Packet<ip::V4Packet<'a, P>>,
+}
+
+pub struct RawPacket<'a, P: Payload> {
+    pub handle: Handle<'a>,
+    pub payload: &'a mut P,
+}
+
+/// A reference to the endpoint of layers below (phy + eth + ip).
+///
+/// This is not really useful on its own but should instead be used either within a `Packet` or a
+/// `RawPacket`. Some of the methods offered there will access the non-public members of this
+/// struct to fulfill their task.
+pub struct Handle<'a> {
+    pub(crate) inner: ip::Handle<'a>,
+    // Nothing more, there is no logic here.
+}
+
+pub enum Init {
+    EchoRequest {
+        src_mask: IpCidr,
+        dst_addr: IpAddress,
+        ident: u16,
+        seq_no: u16,
+        payload: usize,
+    },
+}
+
+impl<'a> Handle<'a> {
+    pub(crate) fn new(
+        handle: ip::Handle<'a>,
+    ) -> Self {
+        Handle {
+            inner: handle,
+        }
+    }
+
+    /// Get the hardware info for that packet.
+    pub fn info(&self) -> &Info {
+        self.inner.info()
+    }
+
+    /// Proof to the compiler that we can shorten the lifetime arbitrarily.
+    pub fn borrow_mut(&mut self) -> Handle {
+        Handle {
+            inner: self.inner.borrow_mut(),
+        }
+    }
+}
+
+impl<'a, P: Payload> Packet<'a, P> {
+    pub(crate) fn new(
+        handle: Handle<'a>,
+        packet: Icmpv4Packet<ip::V4Packet<'a, P>>)
+    -> Self {
+        Packet {
+            handle,
+            packet,
+        }
+    }
+
+    pub fn reinit(self) -> RawPacket<'a, P>
+        where P: PayloadMut,
+    {
+        RawPacket::new(self.handle, self.packet.into_inner().into_inner().into_inner())
+    }
+
+    /// Called last after having initialized the payload.
+    pub fn send(mut self) -> Result<()>
+        where P: PayloadMut,
+    {
+        let capabilities = self.handle.info().capabilities();
+        let checksum = capabilities.icmpv4().tx_checksum();
+        self.packet.fill_checksum(checksum);
+        let lower = ip::Packet::new(
+            self.handle.inner,
+            ip::IpPacket::V4(self.packet.into_inner()));
+        lower.send()
+    }
+}
+
+impl<'a, P: Payload + PayloadMut> RawPacket<'a, P> {
+    pub(crate) fn new(
+        handle: Handle<'a>,
+        payload: &'a mut P,
+    ) -> Self {
+        RawPacket {
+            handle,
+            payload,
+        }
+    }
+
+    /// Initialize to a valid ip packet.
+    pub fn prepare(self, init: Init) -> Result<Packet<'a, P>> {
+        let lower = ip::RawPacket::new(
+            self.handle.inner,
+            self.payload);
+
+        let lower_init = init.ip_init()?;
+        let prepared = lower.prepare(lower_init)?;
+        let mut packet = match prepared.packet {
+            ip::IpPacket::V4(packet) => packet,
+            ip::IpPacket::V6(_) => unreachable!(),
+        };
+        let repr = init.initialize(&mut packet)?;
+
+        // Reconstruct the handle.
+        let handle = Handle::new(prepared.handle);
+
+        Ok(Packet {
+            handle,
+            packet: Icmpv4Packet::new_unchecked(packet, repr),
+        })
+    }
+}
+
+impl Init {
+    fn initialize(&self, payload: &mut impl PayloadMut) -> Result<Icmpv4Repr> {
+        let repr = self.repr();
+
+        // Assumes length was already dealt with.
+        let packet = icmpv4_packet::new_unchecked_mut(
+            payload.payload_mut().as_mut_slice());
+        repr.emit(packet, Checksum::Ignored);
+
+        Ok(repr)
+    }
+
+    fn repr(&self) -> Icmpv4Repr {
+        match *self {
+            Init::EchoRequest { ident, seq_no, payload, .. } => {
+                Icmpv4Repr::EchoRequest { ident, seq_no, payload }
+            },
+        }
+    }
+
+    fn ip_init(&self) -> Result<ip::Init> {
+        Ok(match *self {
+            Init::EchoRequest { src_mask, payload, dst_addr, .. } => {
+                let len = payload
+                    .checked_add(8)
+                    .ok_or(Error::BadSize)?;
+                ip::Init {
+                    src_mask,
+                    dst_addr,
+                    protocol: IpProtocol::Icmp,
+                    payload: len,
+                }
+            },
+        })
+    }
+}

--- a/src/layer/icmp/packet.rs
+++ b/src/layer/icmp/packet.rs
@@ -18,6 +18,7 @@ pub struct In<'a, P: Payload> {
 ///
 /// Some packets have variable payloads [WIP]. These also contribute to the checksum and are yet to
 /// be initialized.
+#[must_use = "You need to call `send` explicitely on an OutPacket, otherwise no packet is sent."]
 pub struct Out<'a, P: Payload> {
     handle: Handle<'a>,
     packet: Icmpv4Packet<ip::V4Packet<'a, P>>,

--- a/src/layer/icmp/packet.rs
+++ b/src/layer/icmp/packet.rs
@@ -148,6 +148,12 @@ impl<'a, P: Payload> Out<'a, P> {
     }
 }
 
+impl<'a, P: PayloadMut> Out<'a, P> {
+    pub fn payload_mut_slice(&mut self) -> &mut [u8] {
+        self.packet.payload_mut_slice()
+    }
+}
+
 impl<'a, P: Payload + PayloadMut> Raw<'a, P> {
     pub(crate) fn new(
         handle: Handle<'a>,

--- a/src/layer/icmp/tests.rs
+++ b/src/layer/icmp/tests.rs
@@ -1,0 +1,86 @@
+use crate::managed::Slice;
+use crate::nic::{loopback::Loopback, Device};
+use crate::layer::{eth, ip, icmp};
+use crate::wire::{EthernetAddress, Ipv4Address, IpCidr, PayloadMut};
+
+const MAC_ADDR_HOST: EthernetAddress = EthernetAddress([0, 1, 2, 3, 4, 5]);
+const IP_ADDR_HOST: Ipv4Address = Ipv4Address::new(127, 0, 0, 1);
+const MAC_ADDR_OTHER: EthernetAddress = EthernetAddress([6, 5, 4, 3, 2, 1]);
+const IP_ADDR_OTHER: Ipv4Address = Ipv4Address::new(127, 0, 0, 2);
+
+static PING_BYTES: [u8; 50] =
+    [   
+        0xaa, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0xff
+    ];
+
+#[test]
+fn answer_ping() {
+    let mut nic = Loopback::<Vec<u8>>::new(vec![0; 1 << 12].into());
+
+    queue_ping(&mut nic);
+
+    let mut eth = [eth::Neighbor::default(); 1];
+    let mut eth = eth::Endpoint::new(MAC_ADDR_HOST, {
+        let mut eth_cache = eth::NeighborCache::new(&mut eth[..]);
+        eth_cache.fill(IP_ADDR_OTHER.into(), MAC_ADDR_OTHER, None).unwrap();
+        eth_cache
+    });
+
+    let mut ip = [ip::Route::unspecified(); 2];
+    let mut ip = ip::Endpoint::new(IpCidr::new(IP_ADDR_HOST.into(), 24), {
+        let ip_routes = ip::Routes::new(&mut ip[..]);
+        // No routes necessary for local link.
+        ip_routes
+    });
+
+    let mut icmp = icmp::Endpoint::new();
+
+    let recv = nic.rx(1, eth.recv(ip.recv(
+        icmp.answer())));
+
+   assert_eq!(recv, Ok(1));
+}
+
+fn queue_ping(nic: &mut Loopback<Vec<u8>>) {
+    fn prepare_ping<P: PayloadMut>(packet: icmp::RawPacket<P>) {
+        let init = icmp::Init::EchoRequest {
+            src_mask: IpCidr::new(IP_ADDR_OTHER.into(), 32),
+            dst_addr: IP_ADDR_HOST.into(),
+            ident: 0,
+            seq_no: 0,
+            payload: PING_BYTES.len(),
+        };
+        let mut packet = packet.prepare(init)
+            .expect("Can initialize to the host");
+        packet
+            .payload_mut_slice()
+            .copy_from_slice(&PING_BYTES[..]);
+        packet
+            .send()
+            .expect("Can send the packet");
+    }
+
+    let mut eth = [eth::Neighbor::default(); 1];
+    let mut eth = eth::Endpoint::new(MAC_ADDR_OTHER, {
+        let mut eth_cache = eth::NeighborCache::new(&mut eth[..]);
+        eth_cache.fill(IP_ADDR_HOST.into(), MAC_ADDR_HOST, None).unwrap();
+        eth_cache
+    });
+
+    let mut ip = ip::Endpoint::new(
+        IpCidr::new(IP_ADDR_OTHER.into(), 24),
+        ip::Routes::new(Slice::empty()));
+
+    let mut icmp = icmp::Endpoint::new();
+
+    // Queue the ping to be received.
+    nic.tx(1, eth.send(ip.send(
+        icmp.send_with(prepare_ping)))
+    ).expect("Ping can be queued.");
+}

--- a/src/layer/ip/mod.rs
+++ b/src/layer/ip/mod.rs
@@ -23,6 +23,8 @@ pub use packet::{
     IpPacket,
     Packet,
     RawPacket,
+    V4Packet,
+    V6Packet,
 };
 
 pub use route::{

--- a/src/layer/ip/mod.rs
+++ b/src/layer/ip/mod.rs
@@ -21,10 +21,11 @@ pub use packet::{
     Handle,
     Init,
     IpPacket,
-    Packet,
-    RawPacket,
     V4Packet,
     V6Packet,
+    In as InPacket,
+    Out as OutPacket,
+    Raw as RawPacket,
 };
 
 pub use route::{
@@ -33,7 +34,7 @@ pub use route::{
 };
 
 pub trait Recv<P: Payload> {
-    fn receive(&mut self, frame: Packet<P>);
+    fn receive(&mut self, frame: InPacket<P>);
 }
 
 pub trait Send<P: Payload> {

--- a/src/layer/ip/packet.rs
+++ b/src/layer/ip/packet.rs
@@ -17,6 +17,7 @@ pub struct In<'a, P: Payload> {
 ///
 /// While the layers below have been initialized, the payload of the packet has not. Fill it by
 /// grabbing the mutable slice for example.
+#[must_use = "You need to call `send` explicitely on an OutPacket, otherwise no packet is sent."]
 pub struct Out<'a, P: Payload> {
     handle: Handle<'a>,
     packet: IpPacket<'a, P>,
@@ -133,9 +134,6 @@ impl<'a, P: PayloadMut> In<'a, P> {
     pub fn reinit(mut self, init: Init) -> Result<Out<'a, P>> {
         let route = self.handle.route_to(init.dst_addr)?;
         let lower_init = self.handle.init_eth(route, init.payload)?;
-
-        let new_repr = init.ip_repr(route.dst_addr);
-        let raw_repr = self.packet.repr();
 
         let eth_packet = eth::InPacket {
             handle: self.handle.eth,

--- a/src/layer/ip/packet.rs
+++ b/src/layer/ip/packet.rs
@@ -20,9 +20,12 @@ pub struct Handle<'a> {
     endpoint: &'a mut (Endpoint + 'a),
 }
 
+pub type V4Packet<'a, P> = Ipv4Packet<EthernetFrame<&'a mut P>>;
+pub type V6Packet<'a, P> = Ipv6Packet<EthernetFrame<&'a mut P>>;
+
 pub enum IpPacket<'a, P: Payload> {
-    V4(Ipv4Packet<EthernetFrame<&'a mut P>>),
-    V6(Ipv6Packet<EthernetFrame<&'a mut P>>),
+    V4(V4Packet<'a, P>),
+    V6(V6Packet<'a, P>),
 }
 
 /// Initializer for a packet.

--- a/src/layer/ip/tests.rs
+++ b/src/layer/ip/tests.rs
@@ -19,7 +19,7 @@ static PAYLOAD_BYTES: [u8; 50] =
      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
      0x00, 0xff];
 
-fn simple_send<P: PayloadMut>(frame: ip::RawPacket<P>) {
+fn simple_send<P: PayloadMut>(frame: RawPacket<P>) {
     let init = ip::Init {
         src_mask: Ipv4Cidr::UNSPECIFIED.into(),
         dst_addr: IP_ADDR_DST.into(),
@@ -29,15 +29,13 @@ fn simple_send<P: PayloadMut>(frame: ip::RawPacket<P>) {
     let mut prepared = frame.prepare(init)
         .expect("Found no valid routes");
     prepared
-        .packet
-        .payload_mut()
-        .as_mut_slice()
+        .payload_mut_slice()
         .copy_from_slice(&PAYLOAD_BYTES[..]);
     prepared.send()
         .expect("Could actuall egress packet");
 }
 
-fn simple_recv<P: Payload>(frame: Packet<P>) {
+fn simple_recv<P: Payload>(frame: InPacket<P>) {
     assert_eq!(frame.packet.payload().as_slice(), &PAYLOAD_BYTES[..]);
 }
 

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -16,12 +16,13 @@
 //!
 //!   ```text
 //!   Raw --init-->Out
-//!    ^            |
-//!    |            |into_in
-//!    |            |
-//!    \            v
+//!    ^           ^|
+//!    |     reinit||into_in
+//!    |           ||
+//!    \           |v
 //!     \--deinit--In
 //!   ```
+//!
 //! * An endpoint component describing the persistent data of a Host on that layer. A receiver and
 //!   sender can then make use of the layer by borrowing it while supplying the handler for the
 //!   next upper layer.
@@ -37,6 +38,25 @@
 //! ## Sending
 //!
 //! [WIP]
+//!
+//! ## Answering
+//!
+//! Many packets require a specified response from a particular layer. With the performance goal in
+//! mind but under the constraint of memory allocation we may want to utilize the already valid
+//! packet data to construct such an answer in-place of the just received packet. This is important
+//! especially for icmp pings and routing functionality. There are two ways to avoid copying the
+//! data in that case:
+//!
+//! * Allocate an additional packet buffer. The extreme of this option allows arbitrary buffer
+//!   allocation and owning by the user's code which is seldom fit or even possible in resource
+//!   constrained environments. Since buffers then become a contended resource this creates several
+//!   DOS risks as well as buffer bloat.
+//! * Reinitialize the packet header structures in-place while avoiding to write to any of the
+//!   payload. In particular each layer calculates the required new length to which the final layer
+//!   resizes the buffer while ensuring the outer payload is shifted into its new position. Then
+//!   each layer can emit its representation again into the appropriate place. This is what `ethox`
+//!   tries to do and should avoid any shifts if the new headers have the same size as the already
+//!   existing ones.
 //!
 //! ## In-depth packet representation
 //!

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -8,11 +8,29 @@
 //! of a user program while processing does not take place, similar to reconfiguration on the OS
 //! level with utilities such as `arp`, `ifconfig`, etc.
 //!
+//! The general structure of each layer is very similar:
+//!
+//! * Three types of packet encapsulation: In, Raw, and Out. The first represents an incoming
+//!   packet with supported features. The second is a packet buffer that can be initialized utilizing
+//!   the network layers below. And the last is an initialized packet that can be sent outwards.
+//!
+//!   ```text
+//!   Raw --init-->Out
+//!    ^            |
+//!    |            |into_in
+//!    |            |
+//!    \            v
+//!     \--deinit--In
+//!   ```
+//! * An endpoint component describing the persistent data of a Host on that layer. A receiver and
+//!   sender can then make use of the layer by borrowing it while supplying the handler for the
+//!   next upper layer.
+//!
 //! ## Receiving
 //!
 //! Many layer implementations process packets by routing them to layers conceptually above them.
 //! This functionality is provided via abstract traits accepting the processed packets of that
-//! layer which contain the payload to-be-consumed in the layer above. The encapsulation can be
+//! layer which contain the payload to-be-consumed in the layer above. The encapsulation could be
 //! removed if the upper layer does not require any knowledge of the layer below. However, it must
 //! be preserved when one wants to use the lower layer for device or protocol specific actions.
 //!

--- a/src/layer/udp/endpoint.rs
+++ b/src/layer/udp/endpoint.rs
@@ -73,9 +73,8 @@ where
     P: Payload,
     H: Recv<P>,
 {
-    fn receive(&mut self, packet: ip::Packet<P>) {
-        let capabilities = packet.handle.info().capabilities();
-        let ip::Packet { handle, packet } = packet;
+    fn receive(&mut self, ip::InPacket { handle, packet }: ip::InPacket<P>) {
+        let capabilities = handle.info().capabilities();
         let checksum = capabilities.udp().rx_checksum(packet.repr());
 
         let packet = match packet.repr().protocol() {

--- a/src/nic/personality.rs
+++ b/src/nic/personality.rs
@@ -19,6 +19,7 @@ pub struct Personality {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Capabilities {
     ipv4: Protocol,
+    icmpv4: Protocol,
     udp: Udp,
 }
 
@@ -72,8 +73,13 @@ impl Capabilities {
     pub fn no_support() -> Self {
         Capabilities {
             ipv4: Protocol::no_support(),
+            icmpv4: Protocol::no_support(),
             udp: Udp::no_support(),
         }
+    }
+
+    pub fn icmpv4(&self) -> &Protocol {
+        &self.icmpv4
     }
 
     pub fn ipv4(&self) -> &Protocol {

--- a/src/wire/ethernet.rs
+++ b/src/wire/ethernet.rs
@@ -356,7 +356,7 @@ impl Repr {
     }
 
     /// Return the length of a header that will be emitted from this high-level representation.
-    pub fn buffer_len(&self) -> usize {
+    pub fn header_len(&self) -> usize {
         field::PAYLOAD.start
     }
 

--- a/src/wire/icmpv4.rs
+++ b/src/wire/icmpv4.rs
@@ -399,6 +399,11 @@ impl<T: Payload> Packet<T> {
 }
 
 impl<T: PayloadMut> Packet<T> {
+    pub fn payload_mut_slice(&mut self) -> &mut [u8] {
+        icmpv4::new_unchecked_mut(self.buffer.payload_mut())
+            .payload_mut_slice()
+    }
+
     /// Recalculate the checksum if necessary.
     ///
     /// Note that the checksum test can be elided even in a checked parse of the ipv4 frame. This

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -204,6 +204,7 @@ pub use self::ipv6routing::{
     Repr as Ipv6RoutingRepr};
 
 pub use self::icmpv4::{
+    icmpv4 as icmpv4_packet,
     Message as Icmpv4Message,
     DstUnreachable as Icmpv4DstUnreachable,
     Redirect as Icmpv4Redirect,

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -128,6 +128,7 @@ mod tcp;
 
 #[path = "payload.rs"]
 mod payload_impl;
+mod payload_ext;
 
 /// Describes how to handle checksums.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -140,6 +141,7 @@ pub enum Checksum {
 }
 
 pub use self::payload_impl::{Reframe, Payload, PayloadMut, Error as PayloadError, payload};
+pub use self::payload_ext::{ReframePayload, PayloadMutExt};
 
 pub type PayloadResult<T> = core::result::Result<T, PayloadError>;
 

--- a/src/wire/payload.rs
+++ b/src/wire/payload.rs
@@ -54,6 +54,7 @@ pub struct Reframe {
 byte_wrapper!(payload);
 
 /// Error variants for resizing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Error {
     BadSize,
 }

--- a/src/wire/payload_ext.rs
+++ b/src/wire/payload_ext.rs
@@ -1,0 +1,159 @@
+//! Extension traits for payloads.
+use core::ops;
+use super::{PayloadMut, Reframe, PayloadResult};
+
+/// Describes the resizing that keeps a payload intact.
+pub struct ReframePayload {
+    /// Total length of the new buffer.
+    ///
+    /// Must not be smaller than `new_payload.end`.
+    pub length: usize,
+
+    /// The position of the payload before reframing.
+    ///
+    /// Needs to have the same length as `new_payload`.
+    pub old_payload: ops::Range<usize>,
+
+    /// The position of the payload after reframing.
+    ///
+    /// Needs to have the same length as `old_payload`.
+    pub new_payload: ops::Range<usize>,
+}
+
+/// Extends the mutable payload structures with new reorganization methods.
+pub trait PayloadMutExt: PayloadMut {
+    /// Reframe but keep the payload.
+    ///
+    /// The method on the trait protects some arbitrary range of bytes which are in both the source
+    /// and target packet. For reusing some packet content it is however necessary to keep the
+    /// slice regardless of its position while moving it to some new position. This can be realized
+    /// by inserting a move of the packet before or after the reframing operation, depending on its
+    /// position.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "std")] {
+    /// # use ethox::wire::{PayloadMutExt, ReframePayload};
+    /// const PAYLOAD: &[u8] = b"xxxx";
+    /// let mut packet = b"******"[..].to_vec();
+    /// packet[2..6].copy_from_slice(PAYLOAD);
+    ///
+    /// packet.reframe_payload(ReframePayload {
+    ///     length: 10,
+    ///     old_payload: 2..6,
+    ///     new_payload: 6..10,
+    /// })?;
+    ///
+    /// assert_eq!(&packet[6..10], PAYLOAD);
+    /// # }
+    ///
+    /// # Ok::<(), ethox::wire::PayloadError>(())
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This methods panics if the reframe is inconsistent, that is:
+    ///
+    /// * The `old_payload` is not contained in the current frame.
+    /// * The `new_payload` is not contained in the wanted frame.
+    /// * The paylods differ in length.
+    fn reframe_payload(&mut self, frame: ReframePayload) -> PayloadResult<()> {
+        assert!(frame.old_payload.len() == frame.new_payload.len());
+
+        let current_len = self.payload().len();
+        assert!(current_len >= frame.old_payload.end);
+        assert!(frame.length >= frame.new_payload.end);
+        assert!(frame.old_payload.start <= frame.old_payload.end);
+        assert!(frame.new_payload.start <= frame.new_payload.end);
+
+        if frame.length >= frame.old_payload.end { // We move the payload after reframing.
+            // Only reframe if necessary.
+            if frame.length != current_len {
+                self.reframe(Reframe {
+                    length: frame.length,
+                    range: frame.old_payload.clone(), // Actually cloning just two ints.
+                })?;
+            }
+
+            // FIXME: `slice::copy_within` as soon as stable. The following is a specialized
+            // variant of its current nightly implementation.
+            let slice = self.payload_mut().as_mut_slice();
+            assert!(slice.len() == frame.length);
+            unsafe {
+                core::ptr::copy(
+                    slice.get_unchecked(frame.old_payload.start),
+                    slice.get_unchecked_mut(frame.new_payload.start),
+                    frame.old_payload.len(),
+                )
+            }
+        } else { // Need to move the frame before reframing.
+            let slice = self.payload_mut().as_mut_slice();
+            assert!(slice.len() == current_len);
+
+            // FIXME: `slice::copy_within`, see above.
+            unsafe {
+                core::ptr::copy(
+                    slice.get_unchecked(frame.old_payload.start),
+                    slice.get_unchecked_mut(frame.new_payload.start),
+                    frame.old_payload.len(),
+                )
+            }
+
+            if frame.length != current_len {
+                self.reframe(Reframe {
+                    length: frame.length,
+                    range: frame.new_payload,
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: PayloadMut> PayloadMutExt for T { }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cmp::Ordering;
+
+    /// No resizing, just move around.
+    #[test]
+    fn reframe_move() {
+        let mut packet = (0..10).collect::<Vec<_>>();
+
+        // Just moving payload around:
+        packet.reframe_payload(ReframePayload {
+            length: 10,
+            old_payload: 0..5,
+            new_payload: 5..10,
+        }).expect("Should work fine");
+        assert_eq!(packet[5..10].iter().cloned().cmp(0..5), Ordering::Equal);
+    }
+
+    /// Overlapping retraction.
+    #[test]
+    fn reframe_retract() {
+        let mut packet = (0..10).collect::<Vec<_>>();
+        packet.reframe_payload(ReframePayload {
+            length: 7,
+            old_payload: 0..5,
+            new_payload: 2..7,
+        }).expect("Should work fine");
+        assert_eq!(packet[2..7].iter().cloned().cmp(0..5), Ordering::Equal);
+    }
+
+    /// Reframe extending the packet buffer.
+    #[test]
+    fn reframe_extend() {
+        let mut packet = (0..10).collect::<Vec<_>>();
+        packet.reframe_payload(ReframePayload {
+            length: 20,
+            old_payload: 0..5,
+            new_payload: 10..15,
+        }).expect("Should work fine");
+        assert_eq!(packet[10..15].iter().cloned().cmp(0..5), Ordering::Equal);
+    }
+}


### PR DESCRIPTION
'Only' offers answering pings and sending your own for now but 
that's a pretty good baseline. This also makes use of, and thus
tests, eth and ip layer reinitialization and reusing of a buffer of an
incoming packet to directly send another one.