### PR TITLE
Not alloc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,20 +11,12 @@ pub mod storage;
 pub mod time;
 pub mod wire;
 
-#[cfg(all(
-    not(feature = "std"),
-    not(test)))]
-pub(crate) use self::managed::Vec;
 #[cfg(any(
     feature = "std",
     test))]
-pub(crate) use std::vec::Vec;
+extern crate alloc;
 
 #[cfg(all(
     not(feature = "std"),
     not(test)))]
-pub(crate) use self::managed::BTreeMap;
-#[cfg(any(
-    feature = "std",
-    test))]
-pub(crate) use std::collections::BTreeMap;
+pub(crate) use self::managed::alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,13 @@ pub mod storage;
 pub mod time;
 pub mod wire;
 
+/// The `alloc` crate, or a replacement without feature `"std"`.
 #[cfg(any(
     feature = "std",
     test))]
-extern crate alloc;
+pub extern crate alloc;
 
 #[cfg(all(
     not(feature = "std"),
     not(test)))]
-pub(crate) use self::managed::alloc;
+pub use self::managed::alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,12 @@ pub(crate) use self::managed::Vec;
     feature = "std",
     test))]
 pub(crate) use std::vec::Vec;
+
+#[cfg(all(
+    not(feature = "std"),
+    not(test)))]
+pub(crate) use self::managed::BTreeMap;
+#[cfg(any(
+    feature = "std",
+    test))]
+pub(crate) use std::collections::BTreeMap;

--- a/src/managed/map.rs
+++ b/src/managed/map.rs
@@ -1,2 +1,18 @@
 use super::Ordered;
 
+/// A map on owned or non-owned data.
+///
+///
+pub enum Map<'a, K: Ord, V> {
+    Pairs(Ordered<'a, (K, V)>),
+
+    /// An owned btree map.
+    ///
+    /// Note that this refers to a phantom data structure from this crate (that can no be
+    /// constructed) when the feature `std` is not enabled. Since this struct is not provided by
+    /// this enum but by its user this is no problem. Quite the opposite, it allows structs which
+    /// contain a `Map` and thus must match on its (public) variants to be written without
+    /// `#[cfg(..)]` tricks to toggle match arms.
+    Btree(crate::BTreeMap<K, V>),
+}
+

--- a/src/managed/map.rs
+++ b/src/managed/map.rs
@@ -1,5 +1,5 @@
 use super::List;
-use alloc::collections::btree_map;
+use crate::alloc::collections::btree_map;
 
 /// A map on owned or non-owned data.
 ///

--- a/src/managed/map.rs
+++ b/src/managed/map.rs
@@ -1,10 +1,15 @@
-use super::Ordered;
+use super::List;
+use alloc::collections::btree_map;
 
 /// A map on owned or non-owned data.
 ///
 ///
 pub enum Map<'a, K: Ord, V> {
-    Pairs(Ordered<'a, (K, V)>),
+    /// The primitive option for a map, a list of pairs.
+    ///
+    /// Only use this for very small maps where it should be expected that simple traversal is
+    /// faster or about as fast as binary search (e.g. `len=4`).
+    Pairs(List<'a, (K, V)>),
 
     /// An owned btree map.
     ///
@@ -13,6 +18,6 @@ pub enum Map<'a, K: Ord, V> {
     /// this enum but by its user this is no problem. Quite the opposite, it allows structs which
     /// contain a `Map` and thus must match on its (public) variants to be written without
     /// `#[cfg(..)]` tricks to toggle match arms.
-    Btree(crate::BTreeMap<K, V>),
+    Btree(btree_map::BTreeMap<K, V>),
 }
 

--- a/src/managed/map.rs
+++ b/src/managed/map.rs
@@ -21,3 +21,90 @@ pub enum Map<'a, K: Ord, V> {
     Btree(btree_map::BTreeMap<K, V>),
 }
 
+/// An entry of the map.
+///
+/// Can be inspected, filled, or removed depending on its state variant.
+pub enum Entry<'map, 'a, K: Ord, V> {
+    Occupied(OccupiedEntry<'map, 'a, K, V>),
+    Vacant(VacantEntry<'map, 'a, K, V>),
+    Full,
+}
+
+pub struct OccupiedEntry<'map, 'a, K: Ord, V> {
+    inner: Occupied<'map, 'a, K, V>,
+}
+
+enum Occupied<'map, 'a, K, V> {
+    Pairs {
+        list: &'map mut List<'a, (K, V)>,
+        index: usize,
+    },
+    Btree(btree_map::OccupiedEntry<'map, K, V>),
+}
+
+pub struct VacantEntry<'map, 'a, K: Ord, V> {
+    inner: Vacant<'map, 'a, K, V>,
+}
+
+enum Vacant<'map, 'a, K, V> {
+    Pairs {
+        list: &'map mut List<'a, (K, V)>,
+    },
+    Btree(btree_map::VacantEntry<'map, K, V>),
+}
+
+
+impl<K: Ord, V> Map<'_, K, V> {
+    pub fn get(&self, key: &K) -> Option<&V> {
+        match self {
+            Map::Pairs(list) => list
+                .as_slice()
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, val)| val),
+            Map::Btree(tree) => tree.get(key),
+        }
+    }
+}
+
+impl<'a, K: Ord, V> Map<'a, K, V> {
+    pub fn entry(&mut self, key: K) -> Entry<'_, 'a, K, V> {
+        match self {
+            Map::Pairs(list) => {
+                let index = list
+                    .as_slice()
+                    .iter()
+                    .position(|(k, _)| k == &key);
+                match index {
+                    Some(index) => Entry::Occupied(OccupiedEntry {
+                        inner: Occupied::Pairs {
+                            list,
+                            index,
+                        },
+                    }),
+                    None => Entry::Vacant(VacantEntry {
+                        inner: Vacant::Pairs {
+                            list,
+                        },
+                    }),
+                }
+            },
+            Map::Btree(tree) => tree.entry(key).into(),
+        }
+    }
+}
+
+impl<'a, K: Ord, V>
+    From<btree_map::Entry<'a, K, V>>
+for Entry<'a, '_, K, V> {
+    fn from(entry: btree_map::Entry<'a, K, V>) -> Self {
+       match entry {
+           btree_map::Entry::Occupied(occ) => Entry::Occupied(OccupiedEntry {
+               inner: Occupied::Btree(occ),
+           }),
+           btree_map::Entry::Vacant(vac) => Entry::Vacant(VacantEntry {
+               inner: Vacant::Btree(vac),
+           }),
+       }
+    }
+}

--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -15,9 +15,19 @@ pub type List<'a, T> = Partial<Slice<'a, T>>;
 #[cfg(all(
     not(feature = "std"),
     not(test)))]
-pub(crate) use self::phantom_vec::Vec;
+pub(crate) mod alloc {
+    pub use managed::phantom_vec::Vec;
 
-#[cfg(all(
-    not(feature = "std"),
-    not(test)))]
-pub(crate) use self::phantom_btree::BTreeMap;
+    pub(crate) mod collections {
+        pub use managed::phantom_btree::BTreeMap;
+
+        pub(crate) mod btree_map {
+            pub use managed::phantom_btree::*;
+        }
+    }
+}
+
+#[cfg(any(
+    feature = "std",
+    test))]
+pub(crate) use ::alloc;

--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -1,9 +1,11 @@
+mod map;
 mod ordered;
 mod partial;
 mod phantom_vec;
 mod phantom_btree;
 mod slice;
 
+pub use self::map::Map;
 pub use self::slice::Slice;
 pub use self::ordered::Ordered;
 pub use self::partial::Partial;

--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -4,11 +4,13 @@ mod partial;
 mod phantom_vec;
 mod phantom_btree;
 mod slice;
+mod slotmap;
 
 pub use self::map::Map;
-pub use self::slice::Slice;
 pub use self::ordered::Ordered;
 pub use self::partial::Partial;
+pub use self::slice::Slice;
+pub use self::slotmap::SlotMap;
 
 pub type List<'a, T> = Partial<Slice<'a, T>>;
 

--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -4,13 +4,13 @@ mod partial;
 mod phantom_vec;
 mod phantom_btree;
 mod slice;
-mod slotmap;
+pub mod slotmap;
 
 pub use self::map::Map;
 pub use self::ordered::Ordered;
 pub use self::partial::Partial;
 pub use self::slice::Slice;
-pub use self::slotmap::SlotMap;
+pub use self::slotmap::{SlotMap, Slot};
 
 pub type List<'a, T> = Partial<Slice<'a, T>>;
 

--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -1,6 +1,7 @@
 mod ordered;
 mod partial;
 mod phantom_vec;
+mod phantom_btree;
 mod slice;
 
 pub use self::slice::Slice;
@@ -13,3 +14,8 @@ pub type List<'a, T> = Partial<Slice<'a, T>>;
     not(feature = "std"),
     not(test)))]
 pub(crate) use self::phantom_vec::Vec;
+
+#[cfg(all(
+    not(feature = "std"),
+    not(test)))]
+pub(crate) use self::phantom_btree::BTreeMap;

--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -15,19 +15,16 @@ pub type List<'a, T> = Partial<Slice<'a, T>>;
 #[cfg(all(
     not(feature = "std"),
     not(test)))]
-pub(crate) mod alloc {
-    pub use managed::phantom_vec::Vec;
+pub mod alloc {
+    pub mod collections {
+        pub use crate::managed::phantom_btree::BTreeMap;
 
-    pub(crate) mod collections {
-        pub use managed::phantom_btree::BTreeMap;
-
-        pub(crate) mod btree_map {
-            pub use managed::phantom_btree::*;
+        pub mod btree_map {
+            pub use crate::managed::phantom_btree::*;
         }
     }
-}
 
-#[cfg(any(
-    feature = "std",
-    test))]
-pub(crate) use ::alloc;
+    pub mod vec {
+        pub use crate::managed::phantom_vec::Vec;
+    }
+}

--- a/src/managed/partial.rs
+++ b/src/managed/partial.rs
@@ -58,6 +58,11 @@ impl<C> Partial<C> {
         self.end
     }
 
+    /// Check if the list is empty.
+    pub fn is_empty(&self) -> bool {
+        self.end == 0
+    }
+
     /// Simply increase the length.
     pub fn inc(&mut self) {
         self.end += 1;
@@ -78,6 +83,15 @@ impl<C, T> Partial<C>
             inner,
             end,
         }
+    }
+
+    /// Check how many elements can be inserted at most.
+    ///
+    /// This results in the length of the underlying container, not its capacity since the
+    /// `Partial` is not aware of reallocation or other behaviour to change the underlying
+    /// containers length.
+    pub fn capacity(&self) -> usize {
+        self.inner.len()
     }
 
     /// Get the logically active elements as a slice.

--- a/src/managed/partial.rs
+++ b/src/managed/partial.rs
@@ -105,7 +105,7 @@ impl<C, T> Partial<C>
     pub fn get<'a, I>(&'a self, idx: I) -> Option<&'a I::Output>
         where I: SliceIndex<[T]>, T: 'a,
     {
-        self.inner.get(idx)
+        self.as_slice().get(idx)
     }
 }
 
@@ -173,7 +173,7 @@ impl<C, T> Partial<C>
     pub fn get_mut<'a, I>(&'a mut self, idx: I) -> Option<&'a mut I::Output>
         where I: SliceIndex<[T]>, T: 'a,
     {
-        self.inner.get_mut(idx)
+        self.as_mut_slice().get_mut(idx)
     }
 }
 
@@ -262,5 +262,9 @@ mod tests {
             let element = partial.pop().expect("Still one left");
             assert_eq!(*element, i);
         }
+
+        // Now we can no longer access any element.
+        assert_eq!(partial.get(0), None);
+        assert_eq!(partial.get_mut(0), None);
     }
 }

--- a/src/managed/phantom_btree.rs
+++ b/src/managed/phantom_btree.rs
@@ -19,7 +19,7 @@ use core::ptr::NonNull;
 /// ## Usage
 ///
 /// ```
-/// use crate::BTreeMap;
+/// use ethox::alloc::collections::btree_map::BTreeMap;
 ///
 /// /// A pure consumer of `BTreeMap`.
 /// ///

--- a/src/managed/phantom_btree.rs
+++ b/src/managed/phantom_btree.rs
@@ -1,4 +1,6 @@
 //! An uninhabited type masquerading as `BTreeMap<_, _>`.
+#![allow(unused, dead_code)]
+
 use core::borrow::Borrow;
 use core::marker::PhantomData;
 use core::ptr::NonNull;
@@ -100,4 +102,38 @@ pub struct VacantEntry<'a, K, V> {
 pub struct OccupiedEntry<'a, K, V> {
     phantom: PhantomData<&'a (K, V)>,
     void: Void,
+}
+
+impl<K, V> OccupiedEntry<'_, K, V> {
+    pub fn get_mut(&mut self) -> &mut V {
+        match self.void { }
+    }
+
+    pub fn remove(self) { }
+
+    pub fn remove_entry(self) -> (K, V) {
+        match self.void { }
+    }
+}
+
+impl<'a, K, V> OccupiedEntry<'a, K, V> {
+    pub fn into_mut(self) -> &'a mut V {
+        match self.void { }
+    }
+}
+
+impl<K, V> VacantEntry<'_, K, V> {
+    pub fn key(&self) -> &K {
+        match self.void { }
+    }
+
+    pub fn into_key(self) -> K {
+        match self.void { }
+    }
+}
+
+impl<'a, K, V> VacantEntry<'a, K, V> {
+    pub fn insert(self, value: V) -> &'a mut V {
+        match self.void { }
+    }
 }

--- a/src/managed/phantom_btree.rs
+++ b/src/managed/phantom_btree.rs
@@ -1,0 +1,85 @@
+//! An uninhabited type masquerading as `BTreeMap<_, _>`.
+use core::borrow::Borrow;
+use core::marker::PhantomData;
+use core::ptr::NonNull;
+
+/// A phantom data type mimicking `BTreeMap`.
+///
+/// The interface provided is the same as the `BTreeMap` but it can not be instantiated. This makes
+/// the implementation of most methods empty. The benefit of having this data type is that methods,
+/// structs, and modules can be written without regards to the support for the `alloc`/`std`
+/// feature so long as they never try to instantiate a `BTreeMap` themselves. Code that only works
+/// with instances or references to them given to it from the outside **compiles** and the compiler
+/// will be deduce that it can never execute.
+///
+/// This allows large portions of the library to be written independent from the configuration and
+/// feature options without leading to actual code bloat. It is up to the eventual consumer of the
+/// library to choose the `BTreeMap` provider and instantiate instances if it is possible.
+///
+/// ## Usage
+///
+/// ```
+/// use crate::BTreeMap;
+///
+/// /// A pure consumer of `BTreeMap`.
+/// ///
+/// /// If this type were not available this would have to be marked with
+/// /// #[cfg(feature = "std")] 
+/// /// otherwise it would not compile as `BTreeMap` would reference a non-existant type. But since
+/// /// it does not instantiate one the phantom mimick allows us to still use its interface. The
+/// /// compiler will (likely) realize no instance can be created and mark this as unreachable.
+/// fn insert_a_val(map: &mut BTreeMap<u32, u32>) {
+///     map.insert(0, 42);
+/// }
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BTreeMap<K: Ord, V> {
+    // We pretend to own (K, V) pairs.
+    elements: PhantomData<NonNull<(K, V)>>,
+    data: Void,
+}
+
+#[allow(unused, dead_code)]
+impl<K: Ord, V> BTreeMap<K, V> {
+    pub fn clear(&mut self) { }
+
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized, 
+    { 
+        match self.data { }
+    }
+
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized, 
+    { 
+        match self.data { }
+    }
+
+    pub fn get_mut<Q>(&self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized, 
+    { 
+        match self.data { }
+    }
+
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        match self.data { }
+    }
+    
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized, 
+    {
+        match self.data { }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum Void { }
+

--- a/src/managed/phantom_btree.rs
+++ b/src/managed/phantom_btree.rs
@@ -78,8 +78,26 @@ impl<K: Ord, V> BTreeMap<K, V> {
     {
         match self.data { }
     }
+
+    pub fn entry(&mut self, key: K) -> Entry<K, V> {
+        match self.data { }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum Void { }
 
+pub enum Entry<'a, K, V> {
+    Vacant(VacantEntry<'a, K, V>),
+    Occupied(OccupiedEntry<'a, K, V>),
+}
+
+pub struct VacantEntry<'a, K, V> {
+    phantom: PhantomData<&'a (K, V)>,
+    void: Void,
+}
+
+pub struct OccupiedEntry<'a, K, V> {
+    phantom: PhantomData<&'a (K, V)>,
+    void: Void,
+}

--- a/src/managed/phantom_vec.rs
+++ b/src/managed/phantom_vec.rs
@@ -1,4 +1,6 @@
 //! A uninhabited type masquerading as `Vec<_>`.
+#![allow(unused, dead_code)]
+
 use core::marker::PhantomData;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -7,7 +9,6 @@ pub struct Vec<T> {
     data: Void,
 }
 
-#[allow(unused, dead_code)]
 impl<T> Vec<T> {
     pub fn as_slice(&self) -> &[T] {
         match self.data { }

--- a/src/managed/slice.rs
+++ b/src/managed/slice.rs
@@ -1,6 +1,8 @@
 use core::ops;
 use core::slice;
 
+use crate::alloc;
+
 /// A list of mutable objects.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Slice<'a, T: 'a> {

--- a/src/managed/slice.rs
+++ b/src/managed/slice.rs
@@ -11,7 +11,7 @@ pub enum Slice<'a, T: 'a> {
     One(T),
 
     /// An allocated list of objects.
-    Many(crate::Vec<T>),
+    Many(alloc::vec::Vec<T>),
 
     /// A list of objects living in borrowed memory.
     ///
@@ -60,8 +60,8 @@ impl<T> From<Option<T>> for Slice<'_, T> {
     }
 }
 
-impl<T> From<crate::Vec<T>> for Slice<'_, T> {
-    fn from(t: crate::Vec<T>) -> Self {
+impl<T> From<alloc::vec::Vec<T>> for Slice<'_, T> {
+    fn from(t: alloc::vec::Vec<T>) -> Self {
         Slice::Many(t)
     }
 }

--- a/src/managed/slotmap.rs
+++ b/src/managed/slotmap.rs
@@ -1,0 +1,319 @@
+use super::{List, Slice};
+
+/// Provides links between slots and elements.
+///
+/// The benefit of separating this struct from the elements is that it is unconditionally `Copy`
+/// and `Default`. It also provides better locality for both the indices and the elements which
+/// could help with iteration or very large structs.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Slot {
+    /*
+    /// Back link of an element to its slot.
+    ///
+    /// The `Slot` at index `i` provides the mapping for the element at index `i` and its
+    /// `index_to_slot` is the index of the slot owning that element. This makes it possible for
+    /// the `SlotMap` to swap elements within their containing slice while updating the index
+    /// structure in constant time. This in turn keeps the element list organized as a pure stack
+    /// even in the face of element removal.
+    index_to_slot: usize,
+    */
+
+    /// The id of this slot.
+    ///
+    /// If the given out index mismatches the `generation_id` then the element was removed already
+    /// and we can return `None` on lookup.
+    ///
+    /// If the slot is currently unused we will instead provide the index to the previous slot in
+    /// the slot-free-list.
+    generation_id: GenerationOrFreelink,
+}
+
+/// Provides a slotmap based on external memory.
+///
+/// A slotmap provides a `Vec`-like interface where each entry is associated with a stable
+/// index-like key. Lookup with the key will detect if an entry has been removed but does not
+/// require and lifetime relation.
+pub struct SlotMap<'a, T> {
+    elements: Slice<'a, T>,
+    slots: List<'a, Slot>,
+    generation: Generation,
+    free_top: usize,
+    indices: IndexComputer,
+}
+
+/// An index into a slotmap.
+///
+/// The index remains valid until the entry is removed. If accessing the slotmap with the index
+/// again after the entry was removed will fail, even if the index where the element was previously
+/// stored has been reused for another element.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Key {
+    idx: usize,
+    generation: Generation,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+struct GenerationOrFreelink(isize);
+
+/// Newtype wrapper around the index of a free slot.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+struct FreeIndex(usize);
+
+/// The generation counter.
+/// 
+/// Has strictly positive values.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct Generation(isize);
+
+/// Offset of a freelist entry to the next entry.
+///
+/// The base for the offset is the *next* element for two reasons:
+/// * Offset of `0` points to the natural successor.
+/// * Offset of `len` would point to the element itself and should not occur.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct Offset(isize);
+
+/// Links FreeIndex and Offset.
+struct IndexComputer(usize);
+
+impl<T> SlotMap<'_, T> {
+    /// Get a mutable reference to the element that would be pushed next.
+    pub fn init(&mut self) -> Option<&mut T> {
+        let index = self.free()?;
+        Some(&mut self.elements[index.0])
+    }
+
+    /// Retrieve a value by index.
+    pub fn get(&self, index: Key) -> Option<&T> {
+        let slot_generation = self.slots
+            .get(index.idx)?
+            .generation_id
+            .generation().ok()?;
+
+        if slot_generation != index.generation {
+            return None;
+        }
+
+        self.elements.get(index.idx)
+    }
+
+    /// Retrieve a mutable value by index.
+    pub fn get_mut(&mut self, index: Key) -> Option<&mut T> {
+        let slot_generation = self.slots
+            .get(index.idx)?
+            .generation_id
+            .generation().ok()?;
+
+        if slot_generation != index.generation {
+            return None;
+        }
+
+        self.elements.get_mut(index.idx)
+    }
+
+    /// Reserve a new entry.
+    pub fn reserve(&mut self) -> Option<(Key, &mut T)> {
+        let index = self.free()?;
+        let slot = &mut self.slots[index.0];
+        let element = &mut self.elements[index.0];
+
+        let offset = slot.generation_id
+            .free_link()
+            .expect("Free link should be free");
+        slot.generation_id = self.generation.into();
+        let key = Key {
+            idx: index.0,
+            generation: self.generation,
+        };
+
+        self.free_top = self.indices.free_list_next(index, offset);
+        self.generation.advance();
+        Some((key, element))
+    }
+
+    /// Sugar wrapper around `reserve` for inserting values.
+    ///
+    /// Note that on success, an old value stored in the backing slice will be overwritten.
+    pub fn insert(&mut self, value: T) -> Option<Key> {
+        // Insertion must work but we don't care about the value.
+        let (index, element) = self.reserve()?;
+        *element = value;
+        Some(index)
+    }
+
+    /// Remove an element.
+    ///
+    /// If successful, return a mutable reference to the removed element. Returns `None` if the
+    /// provided index did not refer to an element that could be freed.
+    pub fn remove(&mut self, index: Key) -> Option<&mut T> {
+        if self.get(index).is_none() {
+            return None
+        }
+
+        // The slot can be freed.
+        let free = FreeIndex(index.idx);
+        let slot = &mut self.slots[index.idx];
+        assert!(slot.generation_id.generation().is_ok());
+
+        let offset = self.indices.free_list_offset(free, self.free_top);
+        slot.generation_id = offset.into();
+        self.free_top = index.idx;
+
+        Some(&mut self.elements[index.idx])
+    }
+
+    /// Get the next free slot.
+    fn free(&mut self) -> Option<FreeIndex> {
+        // If free_top is one-past-the-end marker one of those is going to fail. Note that this
+        // also means extracting one of these statements out of the function may change the
+        // semantics if `elements.len() != slots.len()`.
+
+        // Ensure the index refers to an element within the slice or try to allocate a new slot
+        // wherein we can fit the element.
+        let free = match self.slots.get_mut(self.free_top) {
+            Some(_) => {
+                // Ensure that there is also a real element there.
+                let _= self.elements.get_mut(self.free_top)?;
+                FreeIndex(self.free_top)
+            },
+            None => { // Try to get the next one
+                // Will not actually wrap if pushing is successful.
+                let new_index = self.slots.len();
+                // Ensure there is an element where we want to push to.
+                let _ = self.elements.get_mut(new_index)?;
+
+                let free_slot = self.slots.push()?;
+                let free_index = FreeIndex(new_index);
+                let new_top = new_index.checked_add(1).unwrap();
+
+                let offset = self.indices.free_list_offset(free_index, new_top);
+                free_slot.generation_id = offset.into();
+                self.free_top = free_index.0;
+
+                free_index
+            }
+        };
+
+
+        // index refers to elements within the slices
+        Some(free)
+    }
+}
+
+impl<'a, T> SlotMap<'a, T> {
+    pub fn new(elements: Slice<'a, T>, slots: Slice<'a, Slot>) -> Self {
+        let capacity = elements.len().min(slots.len());
+        SlotMap {
+            elements,
+            slots: List::new(slots),
+            generation: Generation::default(),
+            free_top: 0,
+            indices: IndexComputer::from_capacity(capacity),
+        }
+    }
+}
+
+impl GenerationOrFreelink {
+    pub fn free_link(self) -> Result<Offset, Generation> {
+        if self.0 > 0 {
+            Err(Generation(self.0))
+        } else {
+            Ok(Offset(self.0))
+        }
+    }
+
+    pub fn generation(self) -> Result<Generation, Offset> {
+        if self.0 > 0 {
+            Ok(Generation(self.0))
+        } else {
+            Err(Offset(self.0))
+        }
+    }
+}
+
+impl IndexComputer {
+    pub fn from_capacity(capacity: usize) -> Self {
+        assert!(capacity < isize::max_value() as usize);
+        IndexComputer(capacity)
+    }
+
+    /// Get the next free list entry.
+    fn free_list_next(&self, FreeIndex(base): FreeIndex, offset: Offset)
+        -> usize
+    {
+        let length = self.0;
+        let offset = offset.int_offset();
+
+        assert!(base < length);
+        assert!(offset <= length);
+        let base = base + 1;
+
+        if length - offset <= base {
+            offset + base // Fine within the range
+        } else {
+            // Wrap once, mod (length + 1), result again in range
+            offset
+                .wrapping_add(base)
+                .wrapping_sub(length)
+                // Still > 0
+                .wrapping_sub(1)
+        }
+    }
+
+    fn free_list_offset(&self, FreeIndex(base): FreeIndex, to: usize)
+        -> Offset
+    {
+        let length = self.0;
+
+        assert!(base != to, "Cant offset element to itself");
+        assert!(base < length, "Should never have to offset the end-of-list marker");
+        assert!(to <= length, "Can only offset to the end-of-list marker");
+        let base = base + 1;
+
+        Offset::from_int_offset(if base <= to {
+            to - base
+        } else {
+            // Wrap once, mod (length + 1), result again in range
+            to
+                .wrapping_add(length)
+                .wrapping_add(1)
+                .wrapping_sub(base)
+        })
+    }
+}
+
+impl Generation {
+    pub fn advance(&mut self) {
+        assert!(self.0 > 0);
+        self.0 = self.0.wrapping_add(1).max(1)
+    }
+}
+
+impl Offset {
+    pub fn from_int_offset(offset: usize) -> Self {
+        assert!(offset < isize::max_value() as usize);
+        Offset((offset as isize).checked_neg().unwrap())
+    }
+
+    pub fn int_offset(self) -> usize {
+        self.0.checked_neg().unwrap() as usize
+    }
+}
+
+impl Default for Generation {
+    fn default() -> Self {
+        Generation(1)
+    }
+}
+
+impl From<Generation> for GenerationOrFreelink {
+    fn from(gen: Generation) -> GenerationOrFreelink {
+        GenerationOrFreelink(gen.0)
+    }
+}
+
+impl From<Offset> for GenerationOrFreelink {
+    fn from(offset: Offset) -> GenerationOrFreelink {
+        GenerationOrFreelink(offset.0)
+    }
+}

--- a/src/wire/payload.rs
+++ b/src/wire/payload.rs
@@ -254,7 +254,7 @@ impl PayloadMut for Slice<'_, u8> {
 }
 
 mod std_impls {
-    use crate::Vec;
+    use alloc::vec::Vec;
     use super::{Error, Reframe, Payload, PayloadMut, payload};
 
     impl Payload for Vec<u8> {

--- a/src/wire/payload.rs
+++ b/src/wire/payload.rs
@@ -254,7 +254,7 @@ impl PayloadMut for Slice<'_, u8> {
 }
 
 mod std_impls {
-    use alloc::vec::Vec;
+    use crate::alloc::vec::Vec;
     use super::{Error, Reframe, Payload, PayloadMut, payload};
 
     impl Payload for Vec<u8> {


### PR DESCRIPTION
Moves the allocation free containers into a more contained structure that emulates the recently stabilized standard library part `alloc`. A `SlotMap` is supposed to give a `Vec` with stable keys under deletion which is required (or at least highly useful) to stateful interfaces such as the TCP. 

Oh god I've been infected, the RFC 793 feels almost evangelistic with its pristine usage of pronouns for the acronym. Whereas the RFC for udp (768) slips up on the first page:

> This checksum procedure is the same as is used in [sic! missing pronoun] TCP.

Anyways.