### PR TITLE
Fix retransmit and stream offset errors in Tcp

### DIFF
--- a/ethox/examples/curl.rs
+++ b/ethox/examples/curl.rs
@@ -23,7 +23,9 @@ fn main() {
 
     let mut eth = eth::Endpoint::new(hostmac);
 
+    // Buffer space for arp neighbor cache
     let mut neighbors = [eth::Neighbor::default(); 1];
+    // Buffer space for routes, we only have a single state one.
     let mut routes = [ip::Route::new_ipv4_gateway(gateway.address()); 1];
     let mut ip = ip::Endpoint::new(Slice::One(host.into()),
         ip::Routes::import(List::new_full(routes.as_mut().into())),

--- a/ethox/src/layer/arp/neighbor.rs
+++ b/ethox/src/layer/arp/neighbor.rs
@@ -208,10 +208,12 @@ impl<'a> Cache<'a> {
                 }
             }
 
+            /*
             println!("Refreshed entry {}: {:?} - expiry: {:?}", 
                  new_neighbor.protocol_addr,
                  new_neighbor.hardware_addr,
                  new_neighbor.expires_at);
+                 */
             let _old = self.storage.replace_at(index, new_neighbor)
                 .expect("Sorting didn't change since we only have one entry per protocol addr");
             return Ok(());

--- a/ethox/src/layer/tcp/connection.rs
+++ b/ethox/src/layer/tcp/connection.rs
@@ -437,18 +437,22 @@ impl Connection {
         }
     }
 
-    pub fn open(&mut self, time: Instant, entry: EntryKey) -> Option<TcpRepr> {
+    pub fn open(&mut self, time: Instant, entry: EntryKey)
+        -> Result<(), crate::layer::Error>
+    {
         match self.current {
             State::Closed | State::Listen => (),
-            _ => return None,
+            _ => return Err(crate::layer::Error::Illegal),
         }
 
         self.change_state(State::SynSent);
         self.send.initial_seq = entry.initial_seq_num(time);
         self.send.unacked = self.send.initial_seq;
         self.send.next = self.send.initial_seq + 1;
+        // Schedule 'immediate' transmission.
+        self.retransmission_timer = time;
 
-        Some(self.send_open(false, entry.four_tuple()))
+        Ok(())
     }
 
     /// Answers packets on closed sockets with resets.
@@ -864,7 +868,7 @@ impl Connection {
             return self.fast_retransmit(time, entry);
         }
 
-        if self.retransmission_timer > time {
+        if self.retransmission_timer < time {
             // Choose segments to retransmit, in contrast to `fast_retransmit` this may influence
             // multiple next packets.
             return self.start_timeout_retransmit(time, entry);
@@ -925,7 +929,7 @@ impl Connection {
     fn select_syn_retransmit(&mut self, time: Instant, entry: EntryKey)
         -> Option<Segment>
     {
-        if self.retransmission_timer < time {
+        if self.retransmission_timer > time {
             return None;
         }
 
@@ -956,6 +960,7 @@ impl Connection {
     fn start_timeout_retransmit(&mut self, _time: Instant, _entry: EntryKey)
         -> Option<Segment>
     {
+        return None;
         unimplemented!()
     }
 
@@ -1211,10 +1216,9 @@ impl<'a> Operator<'a> {
         connection.next_send_segment(available, time, entry_key)
     }
 
-    pub fn open(&mut self, time: Instant) -> Result<TcpRepr, crate::layer::Error> {
+    pub fn open(&mut self, time: Instant) -> Result<(), crate::layer::Error> {
         let (entry_key, connection) = self.entry().into_key_value();
         connection.open(time, entry_key)
-            .ok_or(crate::layer::Error::Illegal)
     }
 
     /// Remove the connection and close the operator.
@@ -1301,7 +1305,7 @@ mod tests {
         let time_resend = Instant::from_secs(3);
 
         let entry = EntryKey::fake(&mut no_remap, &isn, &mut four);
-        assert!(connection.open(time_start, entry).is_some());
+        assert!(connection.open(time_start, entry).is_ok());
 
         let entry = EntryKey::fake(&mut no_remap, &isn, &mut four);
         let available = AvailableBytes { fin: false, total: 0 };

--- a/ethox/src/layer/tcp/io.rs
+++ b/ethox/src/layer/tcp/io.rs
@@ -146,8 +146,6 @@ impl<B: AsRef<[u8]>> SendBuf for SendOnce<B> {
     fn ack(&mut self, ack: TcpSeqNumber) {
         let previous = *self.at.get_or_insert(ack);
         self.consumed += ack - previous;
-        // FIXME: The ack'ed FIN will be one out-of-bounds otherwise. This is ugly.
-        self.consumed = self.consumed.min(self.data.as_ref().len());
         self.at = Some(ack);
     }
 }

--- a/mininet/tcp-http.py
+++ b/mininet/tcp-http.py
@@ -44,7 +44,7 @@ def simpleTest():
     ethox_tcp = '../target/debug/examples/curl ethoxtap %s/8 %s %s/8 %s %s' % (
         ethox.IP(), ethox.MAC(), host.IP(), host.IP(), 8000)
     # The connection lingers in tcp TimeWait for 6 more seconds (2 full default rtts)
-    answer = ethox.cmd('timeout 8s ' + ethox_tcp)
+    answer = ethox.cmd('timeout 10s ' + ethox_tcp)
     print answer
     print '\n'.join(filter(
         lambda l: not l.startswith('  '),


### PR DESCRIPTION
'curl' now works without arp setup in mininet!