### PR TITLE
Rework SendOnce into SendFrom, a flexible sender

### DIFF
--- a/ethox-iperf3/main.rs
+++ b/ethox-iperf3/main.rs
@@ -42,7 +42,7 @@ fn main() {
     );
     let mut tcp_client = tcp::Client::new(
         Ipv4Address::from(server).into(), server_port,
-        tcp::io::Sink::new(), tcp::io::SendOnce::new(message));
+        tcp::io::Sink::new(), tcp::io::SendFrom::new(message));
 
     let mut interface = TapInterface::new(&name, vec![0; 1 << 14])
         .expect("Couldn't initialize interface");
@@ -71,5 +71,5 @@ struct Config {
     gatemac: EthernetAddress,
     server: net::Ipv4Addr,
     server_port: u16,
-    message: String,
+    message: Vec<u8>,
 }

--- a/ethox/examples/curl.rs
+++ b/ethox/examples/curl.rs
@@ -37,11 +37,11 @@ fn main() {
         tcp::IsnGenerator::from_std_hash(),
     );
 
-    let message = "GET / HTTP/1.0\r\n\r\n".to_owned();
+    let message = "GET / HTTP/1.0\r\n\r\n";
     let mut tcp_client = tcp::Client::new(
         Ipv4Address::from(server).into(), server_port,
         tcp::io::RecvInto::new(vec![0; 1 << 20]),
-        tcp::io::SendOnce::new(message));
+        tcp::io::SendFrom::once(message.as_bytes()));
 
     let mut interface = RawSocket::new(&name, vec![0; 1 << 14])
         .expect(&format!("Couldn't initialize interface {}", name));


### PR DESCRIPTION
Simply track whether the data has been marked as finished. The SendOnce
implementation had to already track all buffer indices just like the
more flexible version so this is an overhead of a single bool in the
state representation, mostly.