### PR TITLE
Iperf server implementation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,9 +12,29 @@ main_task:
       - ETHOX_FEATURES: sys
       - ETHOX_FEATURES: alloc sys
       - ETHOX_FEATURES: std sys
-  build_script: cargo build --no-default-features --features "$ETHOX_FEATURES"
-  test_script: cargo test --no-default-features --features "$ETHOX_FEATURES"
+  build_script:
+    - cd ethox
+    - cargo build --no-default-features --features "$ETHOX_FEATURES"
+  test_script:
+    - cd ethox
+    - cargo test --no-default-features --features "$ETHOX_FEATURES"
   before_cache_script: rm -rf $CARGO_HOME/registry/index
+
+side_crates_task:
+  container:
+    image: rust:latest
+  cargo_cache:
+    folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
+  iperf_script:
+    - cd ethox-iperf
+    - cargo test
+  no_std_script:
+    - cd ethox-no-std
+    - cargo build --release
+    - ls -sh target/release/raw-ping
+    - strip target/release/raw-ping
+    - ls -sh target/release/raw-ping
 
 nightly_task:
   container:
@@ -22,20 +42,14 @@ nightly_task:
   cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock
-  test_all_script: cargo test --all-features
-  before_cache_script: rm -rf $CARGO_HOME/registry/index
-
-no_std_task:
-  container:
-    image: rust:latest
-  cargo_cache:
-    folder: $CARGO_HOME/registry
-    fingerprint_script: cat ethox-no-std/Cargo.lock
-  normal_script: cd ethox-no-std && cargo build
-  release_script: cd ethox-no-std && cargo build --release
+  test_all_script:
+    - cd ethox
+    - cargo test --all-features
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 doc_task:
   container:
     image: rustlang/rust:nightly
-  script: cargo doc --no-deps --document-private-items --all-features
+  script:
+    - cd ethox
+    - cargo doc --no-deps --document-private-items --all-features

--- a/ethox-iperf/bin/main.rs
+++ b/ethox-iperf/bin/main.rs
@@ -3,9 +3,13 @@
 //! Connects to a given remote tcp host and sends a single provided message. Any incoming data is
 //! silently discarded without having been copied into a buffer (but no FIN sent).
 //!
-//! Prepend the ethox configuration to the usual iperf options. Call example:
+//! Prepend the ethox configuration to the usual iperf options. Call example assuming a connected
+//! veth pair `veth0` and `veth1`.
 //!
-//! * `iperf3 tap0 10.0.0.1/24 ab:ff:ff:ff:ff:ff 10.0.0.2/24 -c 10.0.0.2 5001 -n 10000 -l 1470`
+//! * Client: `iperf3 veth0 10.0.0.1/24 ac:ff:ff:ff:ff:ff 10.0.0.2/24 -c 10.0.0.2 5001 -n 10000 -l 1470 --udp`
+//! * Server: `iperf3 veth1 10.0.0.2/24 ac:ff:ff:fe:ff:ff 10.0.0.1/24 -s 5001 --udp`
+//!
+//! (This uses a locally administered unicast MAC address)
 pub use ethox_iperf::{config, iperf2};
 
 use ethox::managed::{List, Slice};

--- a/ethox-iperf/bin/main.rs
+++ b/ethox-iperf/bin/main.rs
@@ -31,7 +31,7 @@ fn main() {
 
     let result = match &config.iperf3 {
         config::Iperf3Config::Client(
-            config::IperfClient { kind: config::ClientKind::Udp, client
+            config::IperfClient { kind: config::Transport::Udp, client
         }) => {
             ethox_iperf::client(
                 &mut interface,
@@ -42,7 +42,7 @@ fn main() {
             )
         },
         config::Iperf3Config::Client(
-            config::IperfClient { kind: config::ClientKind::Tcp, client
+            config::IperfClient { kind: config::Transport::Tcp, client
         }) => {
             ethox_iperf::client(
                 &mut interface,
@@ -52,6 +52,18 @@ fn main() {
                 iperf2::IperfTcp::new(client),
             )
         },
+        config::Iperf3Config::Server(
+            config::IperfServer { kind: config::Transport::Udp, server }
+        ) => {
+            ethox_iperf::server(
+                &mut interface,
+                10,
+                &mut eth,
+                &mut ip,
+                iperf2::Server::new(server),
+            )
+        }
+        _ => unimplemented!("Tcp server is not yet implemented!"),
     };
 
     println!("[+] Done\n");

--- a/ethox-iperf/src/config.rs
+++ b/ethox-iperf/src/config.rs
@@ -48,7 +48,8 @@ pub struct Client {
 
 #[derive(Clone, StructOpt)]
 pub struct Server {
-    pub host: net::Ipv4Addr,
+    #[structopt(short = "B")]
+    pub host: Option<net::Ipv4Addr>,
     pub port: u16,
 }
 

--- a/ethox-iperf/src/config.rs
+++ b/ethox-iperf/src/config.rs
@@ -7,10 +7,13 @@ use ethox::wire::{Ipv4Cidr, EthernetAddress};
 pub enum Iperf3Config {
     #[structopt(name = "-c")]
     Client(IperfClient),
+
+    #[structopt(name = "-s")]
+    Server(IperfServer),
 }
 
 #[derive(Clone, StructOpt)]
-pub enum ClientKind {
+pub enum Transport {
     #[structopt(name = "--udp")]
     Udp,
     #[structopt(name = "--tcp")]
@@ -20,9 +23,17 @@ pub enum ClientKind {
 #[derive(Clone, StructOpt)]
 pub struct IperfClient {
     #[structopt(flatten)]
-    pub kind: ClientKind,
+    pub kind: Transport,
     #[structopt(flatten)]
     pub client: Client,
+}
+
+#[derive(Clone, StructOpt)]
+pub struct IperfServer {
+    #[structopt(flatten)]
+    pub kind: Transport,
+    #[structopt(flatten)]
+    pub server: Server,
 }
 
 #[derive(Clone, StructOpt)]
@@ -33,6 +44,12 @@ pub struct Client {
     pub buffer_bytes: usize,
     #[structopt(short = "n")]
     pub total_bytes: usize,
+}
+
+#[derive(Clone, StructOpt)]
+pub struct Server {
+    pub host: net::Ipv4Addr,
+    pub port: u16,
 }
 
 #[derive(Clone, StructOpt)]

--- a/ethox-iperf/src/iperf2.rs
+++ b/ethox-iperf/src/iperf2.rs
@@ -372,7 +372,7 @@ impl tcp::SendBuf for PatternBuffer {
     }
 }
 
-impl<P: PayloadMut> udp::Send<P> for &'_ mut Connection {
+impl<P: PayloadMut> udp::Send<P> for Connection {
     fn send(&mut self, packet: udp::RawPacket<P>) {
         let ts = packet.handle.info().timestamp();
 
@@ -408,7 +408,7 @@ impl<P: PayloadMut> udp::Send<P> for &'_ mut Connection {
     }
 }
 
-impl<P: PayloadMut> udp::Recv<P> for &'_ mut Connection {
+impl<P: PayloadMut> udp::Recv<P> for Connection {
     fn receive(&mut self, packet: udp::Packet<P>) {
         let repr = packet.packet.repr();
         if repr.dst_port != self.send_init.src_port {

--- a/ethox-iperf/src/iperf3.rs
+++ b/ethox-iperf/src/iperf3.rs
@@ -379,7 +379,7 @@ impl<P: PayloadMut> ip::Send<P> for Iperf3 {
     }
 }
 
-impl<P: PayloadMut> udp::Recv<P> for &'_ mut Handshake {
+impl<P: PayloadMut> udp::Recv<P> for Handshake {
     fn receive(&mut self, packet: udp::Packet<P>) {
         if packet.packet.repr().dst_port == 0 {
             self.shaken = true;

--- a/ethox-iperf/src/lib.rs
+++ b/ethox-iperf/src/lib.rs
@@ -42,3 +42,29 @@ where
         }
     }
 }
+
+/// Just a clone of `client` for now but should be logically used for server.
+pub fn server<Nic>(
+    nic: &mut Nic,
+    burst: usize,
+    eth: &mut ethox::layer::eth::Endpoint,
+    ip: &mut ethox::layer::ip::Endpoint,
+    mut client: impl Client<Nic>,
+) -> Score
+where
+    Nic: ethox::nic::Device,
+    Nic::Payload: ethox::wire::PayloadMut + Sized,
+    Nic::Handle: Sized,
+{
+    // FIXME:
+    // * reset after a client instead of terminate
+    // * accept more than one client
+    loop {
+        let _ = nic.rx(burst, eth.recv(ip.recv(&mut client)));
+        let _ = nic.tx(burst, eth.send(ip.send(&mut client)));
+
+        if let Some(result) = client.result() {
+            return result;
+        }
+    }
+}

--- a/ethox-iperf/src/score.rs
+++ b/ethox-iperf/src/score.rs
@@ -29,7 +29,7 @@ impl Score {
     }
 
     fn loss_rate(&self) -> f32 {
-        (self.packet_count as f32)/(self.total_count as f32)
+        ((self.total_count - self.packet_count) as f32)/(self.total_count as f32)
     }
 }
 
@@ -80,12 +80,12 @@ impl fmt::Display for Score {
            "[{ts}] {begin}-{end} sec\t{total} KBytes\t{rate} Mbits/sec\t{dt} ms\t\
             {loss}/\t{packets} ({loss_percent})",
            ts=3,
-           begin=0.0,
-           end=1.0,
+           // Pretend that start was at 0.0 but otherwise accurate.
+           begin=0.0, end=self.time.as_secs_f32(),
            total=self.total_kb(),
            rate=self.effective_rate(),
-           dt=0.0,
-           loss=0,
+           dt=self.time.as_secs_f32() / 1000.0,
+           loss=self.total_count - self.packet_count,
            packets=self.packet_count,
            loss_percent=self.loss_rate()*100.0,
         )

--- a/ethox-iperf/src/score.rs
+++ b/ethox-iperf/src/score.rs
@@ -51,6 +51,16 @@ impl From<iperf2::TcpResult> for Score {
     }
 }
 
+impl From<iperf2::ServerResult> for Score {
+    fn from(result: iperf2::ServerResult) -> Score {
+        Score {
+            data_len: unimplemented!(),
+            time: unimplemented!(),
+            packet_count: result.packet_count,
+        }
+    }
+}
+
 impl fmt::Display for Score {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Emulate the iperf style:

--- a/ethox-iperf/src/score.rs
+++ b/ethox-iperf/src/score.rs
@@ -54,8 +54,10 @@ impl From<iperf2::TcpResult> for Score {
 impl From<iperf2::ServerResult> for Score {
     fn from(result: iperf2::ServerResult) -> Score {
         Score {
-            data_len: unimplemented!(),
-            time: unimplemented!(),
+            data_len: result.packet_size.into(),
+            // FIXME: proper time measurements? Measuring with real iperf relies on the server side
+            // to fix the effective data rate etc. so it should be captured on server side as well.
+            time: Duration::from_millis(0),
             packet_count: result.packet_count,
         }
     }

--- a/ethox-iperf/src/score.rs
+++ b/ethox-iperf/src/score.rs
@@ -55,9 +55,7 @@ impl From<iperf2::ServerResult> for Score {
     fn from(result: iperf2::ServerResult) -> Score {
         Score {
             data_len: result.packet_size.into(),
-            // FIXME: proper time measurements? Measuring with real iperf relies on the server side
-            // to fix the effective data rate etc. so it should be captured on server side as well.
-            time: Duration::from_millis(0),
+            time: result.duration,
             packet_count: result.packet_count,
         }
     }

--- a/ethox/Cargo.toml
+++ b/ethox/Cargo.toml
@@ -24,18 +24,23 @@ sys = ["libc"]
 [dev-dependencies]
 structopt = { version = "0.2", default-features = false }
 
+# All examples rely on sys and std for some reason.
+#
+# sys: Required to open the underlying sockets.
+# std: Most due to argument parsing (which is done in std) but also to use
+#   stderr and other io portions
 [[example]]
 name = "debug_tap"
-required-features = ["alloc", "sys"]
+required-features = ["alloc", "sys", "std"]
 
 [[example]]
 name = "ping_tap"
-required-features = ["alloc", "sys"]
+required-features = ["alloc", "sys", "std"]
 
 [[example]]
 name = "arp_tap"
-required-features = ["alloc", "sys"]
+required-features = ["alloc", "sys", "std"]
 
 [[example]]
 name = "curl"
-required-features = ["alloc", "sys"]
+required-features = ["alloc", "sys", "std"]

--- a/ethox/src/layer/udp/mod.rs
+++ b/ethox/src/layer/udp/mod.rs
@@ -32,3 +32,19 @@ pub trait Recv<P: Payload> {
 pub trait Send<P: Payload> {
     fn send(&mut self, raw: RawPacket<P>);
 }
+
+impl<P, C> Recv<P> for &'_ mut C
+    where P: Payload, C: Recv<P>,
+{
+    fn receive(&mut self, frame: Packet<P>) {
+        (**self).receive(frame)
+    }
+}
+
+impl<P, C> Send<P> for &'_ mut C
+    where P: Payload, C: Send<P>,
+{
+    fn send(&mut self, frame: RawPacket<P>) {
+        (**self).send(frame)
+    }
+}


### PR DESCRIPTION
Only udp for now. This is compatible with `iperf` as well. It's necessary to really evaluate the `udp` implementation as the pure Linux version does not handle large packet rates well.